### PR TITLE
PostgreSQL Percona pg_tde (TDE) image support

### DIFF
--- a/.github/workflows/build-postgres.yml
+++ b/.github/workflows/build-postgres.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [18.3-alpine, 18.3-bookworm, 18.3-alpine-ext, 18.3-bookworm-ext, 17.9-alpine, 17.9-bookworm, 17.9-alpine-ext, 17.9-bookworm-ext, 17.5-alpine, 17.4-alpine, 17.2-alpine, 16.13-alpine, 16.13-bookworm, 16.13-alpine-ext, 16.13-bookworm-ext, 16.10-alpine, 16.10-bookworm, 16.9-alpine, 16.8-alpine, 16.6-alpine, 16.4-alpine, 16.1-alpine, 15.17-alpine, 15.17-bookworm, 15.13-alpine, 15.12-alpine, 15.10-alpine, 15.8-alpine, 15.5-alpine, 14.22-alpine, 14.22-bookworm, 14.19-alpine, 14.19-bookworm, 14.18-alpine, 14.17-alpine, 14.15-alpine, 14.13-alpine, 14.10-alpine]
+        tag: [18.3-alpine, 18.3-bookworm, 18.3-alpine-ext, 18.3-bookworm-ext, 17.9-alpine, 17.9-bookworm, 17.9-alpine-ext, 17.9-bookworm-ext, 17.9-percona, 17.5-alpine, 17.4-alpine, 17.2-alpine, 16.13-alpine, 16.13-bookworm, 16.13-alpine-ext, 16.13-bookworm-ext, 16.10-alpine, 16.10-bookworm, 16.9-alpine, 16.8-alpine, 16.6-alpine, 16.4-alpine, 16.1-alpine, 15.17-alpine, 15.17-bookworm, 15.13-alpine, 15.12-alpine, 15.10-alpine, 15.8-alpine, 15.5-alpine, 14.22-alpine, 14.22-bookworm, 14.19-alpine, 14.19-bookworm, 14.18-alpine, 14.17-alpine, 14.15-alpine, 14.13-alpine, 14.10-alpine]
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/cmd/build-image/main.go
+++ b/cmd/build-image/main.go
@@ -456,6 +456,8 @@ func FindBlock(dir, name, tag string) (string, *api.Block, error) {
 		filename = filepath.Join(dir, "library", name, "dhi.json")
 	case "ext":
 		filename = filepath.Join(dir, "library", name, "ext.json")
+	case "percona":
+		filename = filepath.Join(dir, "library", name, "tde.json")
 	default:
 		filename = filepath.Join(dir, "library", name, "app.json")
 	}

--- a/library/postgres/build_tags.txt
+++ b/library/postgres/build_tags.txt
@@ -2,6 +2,7 @@
 18.3-bookworm
 17.9-alpine
 17.9-bookworm
+17.9-percona
 17.5-alpine
 17.4-alpine
 17.2-alpine

--- a/library/postgres/tde.json
+++ b/library/postgres/tde.json
@@ -1,0 +1,31 @@
+{
+  "Name": "postgres",
+  "GitRepo": "https://github.com/docker-library/postgres.git",
+  "KnownTags": {},
+  "Blocks": [
+    {
+      "Tags": [
+        "17.9-percona"
+      ],
+      "Architectures": {
+        "amd64": {
+          "Architecture": "amd64",
+          "Directory": "",
+          "GitFetch": "",
+          "GitCommit": "",
+          "File": ""
+        },
+        "arm64v8": {
+          "Architecture": "arm64v8",
+          "Directory": "",
+          "GitFetch": "",
+          "GitCommit": "",
+          "File": ""
+        }
+      },
+      "GitCommit": "f0fc44ac34ae280fcb4e0aaf27040aefa6d19334",
+      "Directory": "tde/17.9/bookworm",
+      "File": "Dockerfile"
+    }
+  ]
+}


### PR DESCRIPTION
Wires up a Percona / `pg_tde` image variant for postgres, mirroring how `-ext`
was added in #91. First tag is **`17.9-percona`**.

## Changes

- **`cmd/build-image/main.go`** — `FindBlock` gains a `percona` case, so a tag
  whose last `-` segment is `percona` resolves to `library/<name>/tde.json`
  (alongside the existing `dhi.json` / `ext.json` / `app.json` cases).
- **`library/postgres/tde.json`** — one block: `17.9-percona`, built from
  `tde/17.9/bookworm` at `appscode-images/postgres@f0fc44a`.
- **`.github/workflows/build-postgres.yml`** — `17.9-percona` added to the build
  matrix, next to the `17.9-*-ext` tags.
- **`library/postgres/build_tags.txt`** — same tag added here too. This is the
  list `cmd/generate-workflows` renders `$tags$` from and the one
  `cmd/mail-report` walks for the CVE report, so the workflow matrix entry only
  survives a workflow regeneration if the tag is here as well.

Result: `ghcr.io/appscode-images/postgres:17.9-percona`.

## Why

KubeDB's Transparent Data Encryption support needs Percona's `pg_tde`, whose
`tde_heap` access method requires the Percona Server for PostgreSQL fork rather
than community PostgreSQL. So TDE needs its own image rather than an extension
layered on top of `postgres:<major>-bookworm`. The Dockerfile still keeps the
same runtime contract (uid/gid 999, binaries under `/usr/lib/postgresql/17/bin`,
upstream entrypoint + gosu, same `PGDATA`/locale/`VOLUME`/`STOPSIGNAL`/`EXPOSE`),
so the existing KubeDB run scripts work against it unchanged.

## Architectures

`tde.json` lists only `amd64` and `arm64v8` — Percona publishes `ppg-17` for
`amd64`, `arm64` and `i386` only, and the builder filters to amd64/arm64 anyway.
Both are present in `repo.percona.com/ppg-17/apt` (bookworm) and in the
`ghcr.io/appscode-images/postgres:17.9-bookworm` donor manifest.

## Verified

- `go build ./...` and `go vet ./cmd/build-image/` clean
- tag resolution exercised directly against the real library files:
  `17.9-percona` → `tde.json` (`dir=tde/17.9/bookworm`, `commit=f0fc44a`,
  2 architectures), while `17.9-bookworm-ext` still resolves to `ext.json` and
  `17.9-bookworm` still resolves to `app.json`
- the Dockerfile builds for `linux/amd64` and reports
  `postgres (PostgreSQL) 17.9 - Percona Server for PostgreSQL 17.9.1`, with
  `pg_tde.control` installed and `pg_tde_basebackup` / `pg_tde_rewind` /
  `pg_tde_waldump` / `pg_tde_resetwal` all executable

## Note on naming

The tag is `17.9-percona` (no distro segment) while the Dockerfile lives at
`tde/17.9/bookworm` — the directory keeps the `<variant>/<version>/<distro>`
layout the `ext`/`dhi` trees use, and the manifest file stays `tde.json` since it
is keyed by capability rather than vendor. Say the word if you'd rather the
directory or file follow the tag name instead.

## Pre-existing gap, not fixed here

The six `-ext` tags and the `-dhi` tags were never added to
`library/postgres/build_tags.txt`, so running `cmd/generate-workflows` today
would drop them from the matrix (and also revert `runs-on: firecracker` and the
pinned action SHAs). Happy to add them in this PR if you want that cleaned up at
the same time.

Postgres repo PR: appscode-images/postgres#1 (branch `tde` is already pushed, so
the commit `f0fc44a` referenced above is fetchable now).